### PR TITLE
Milestone 3: Switch badges for rockets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -47,12 +47,31 @@ nav a.active {
   margin-right: 20px;
 }
 
+.reserved-tag {
+  display: inline-block;
+  background-color: rgb(27, 125, 170);
+  color: white;
+  padding: 5px;
+  margin: 5px;
+  border-radius: 5px;
+}
+
 .reserve-btn {
   background-color: #0290ff;
   border: none;
   padding: 1rem;
   color: white;
   border-radius: 5px;
+  cursor: pointer;
+}
+
+.cancel-reservation {
+  background-color: white;
+  border: 1px solid #d3d3d3;
+  padding: 1rem;
+  color: gray;
+  border-radius: 5px;
+  cursor: pointer;
 }
 
 .reserve-btn:hover {

--- a/src/components/rocket/Rocket.js
+++ b/src/components/rocket/Rocket.js
@@ -1,16 +1,37 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
+import { bookReservation, cancelReservation } from '../../redux/rockets/rockets';
 
-const Rocket = ({ rocket }) => (
-  <div className="rocket-div">
-    <div className="img-div">
-      <img className="rocket-img" src={rocket.flickr_images[0]} alt="Rocket" />
+const Rocket = ({ rocket }) => {
+  const dispatch = useDispatch();
+
+  const handleReservation = (id) => {
+    dispatch(bookReservation(id));
+  };
+
+  const handleCancelReservation = (id) => {
+    dispatch(cancelReservation(id));
+  };
+
+  const reservedText = 'Reserved';
+
+  return (
+    <div className="rocket-div">
+      <div className="img-div">
+        <img className="rocket-img" src={rocket.flickr_images[0]} alt="Rocket" />
+      </div>
+      <div className="rocket-details">
+        <h2>{rocket.rocket_name}</h2>
+        <p>
+          { rocket.reserved ? <span className="reserved-tag">{reservedText}</span> : ''}
+          {rocket.description}
+        </p>
+        {rocket.reserved
+          ? <button type="button" className="cancel-reservation" onClick={() => { handleCancelReservation(rocket.id); }}>Cancel Reservation</button>
+          : <button type="button" className="reserve-btn" onClick={() => { handleReservation(rocket.id); }}>Reserve Rocket</button>}
+      </div>
     </div>
-    <div className="rocket-details">
-      <h2>{rocket.rocket_name}</h2>
-      <p>{rocket.description}</p>
-      <button type="button" className="reserve-btn">Reserve Rocket</button>
-    </div>
-  </div>
-);
+  );
+};
 
 export default Rocket;

--- a/src/components/rocket/RocketPage.js
+++ b/src/components/rocket/RocketPage.js
@@ -8,8 +8,10 @@ const RocketPage = () => {
   const rockets = useSelector((state) => state.rockets.rockets);
 
   useEffect(() => {
-    dispatch(getRockets());
-  }, []);
+    if (rockets.length === 0) {
+      dispatch(getRockets());
+    }
+  }, [dispatch, rockets.length]);
 
   return (
     <div>

--- a/src/index.js
+++ b/src/index.js
@@ -7,11 +7,11 @@ import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
+  // <React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  // </React.StrictMode>,
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -8,13 +8,39 @@ const initialState = {
 const rocketSlice = createSlice({
   name: 'rockets',
   initialState,
+  reducers: {
+    bookReservation(state, action) {
+      const newState = state.rockets.map((rocket) => {
+        if (rocket.id !== action.payload) {
+          return rocket;
+        }
+        return { ...rocket, reserved: true };
+      });
+      return {
+        ...state,
+        rockets: [...newState],
+      };
+    },
+    cancelReservation(state, action) {
+      const newState = state.rockets.map((rocket) => {
+        if (rocket.id !== action.payload) {
+          return rocket;
+        }
+        return { ...rocket, reserved: false };
+      });
+      return {
+        state,
+        rockets: [...newState],
+      };
+    },
+  },
   extraReducers: (builder) => {
     builder.addCase(getRockets.fulfilled, (state, action) => ({
       ...state,
-      rockets: [...action.payload],
+      rockets: action.payload,
     }));
   },
 });
 
-//   export const { addBook, removeBook } = bookSlice.actions;
+export const { bookReservation, cancelReservation } = rocketSlice.actions;
 export default rocketSlice.reducer;


### PR DESCRIPTION
In this branch, I implemented the following: 

- Rockets that have already been reserved show a "Reserved" badge and a "Cancel reservation" button instead of the default "Reserve rocket".
- The "Reserved" badge is removed when the "Cancel reservation" button is clicked.